### PR TITLE
fix(happening-surveys): survey audio and project issues on edit and update

### DIFF
--- a/src/screens/EditSurvey/index.tsx
+++ b/src/screens/EditSurvey/index.tsx
@@ -162,9 +162,11 @@ const EditHappeningSurvey = () => {
             isPublic: isPublic,
             attachment: attachment.map(responseToRNF),
             attachmentLink: imageLinks.map(img => img.id),
-            audioFile: audio,
             modifiedAt: new Date().toISOString(),
         };
+        if (typeof audio !== 'string') {
+            surveyInput.audioFile = audio;
+        }
 
         if (coordinates) {
             surveyInput.location = coordinates.point
@@ -232,7 +234,9 @@ const EditHappeningSurvey = () => {
                                 return img;
                             }),
                             audioFile:
-                                surveyInput?.audioFile as HappeningSurveyType['audioFile'],
+                                typeof audio === 'string'
+                                    ? audio
+                                    : (surveyInput?.audioFile as HappeningSurveyType['audioFile']),
                             category: {
                                 __typename: 'ProtectedAreaCategoryType',
                                 ...surveyCategory,
@@ -405,6 +409,7 @@ const EditHappeningSurvey = () => {
                     projects={projects}
                     activeProject={project}
                     onChange={setProject}
+                    disabled={Boolean(surveyItem?.project)}
                 />
             )}
             <InputField

--- a/src/screens/UpdateSurvey/index.tsx
+++ b/src/screens/UpdateSurvey/index.tsx
@@ -152,6 +152,9 @@ const UpdateSurvey = () => {
             description,
             modifiedAt: new Date().toISOString(),
         };
+        if (typeof audio !== 'string') {
+            surveyInput.audioFile = audio;
+        }
         setProcessing(true);
         await updateHappeningSurvey({
             variables: {input: surveyInput, id: surveyItem.id},
@@ -179,7 +182,9 @@ const UpdateSurvey = () => {
                             ...surveyItem.attachment,
                         ],
                         audioFile:
-                            surveyInput.audioFile as HappeningSurveyType['audioFile'],
+                            typeof audio === 'string'
+                                ? audio
+                                : (surveyInput?.audioFile as HappeningSurveyType['audioFile']),
                         improvement:
                             surveyInput.improvement as HappeningSurveyType['improvement'],
                         isOffline: true,


### PR DESCRIPTION
**Changes**
- Disable project change when editing happening survey if project is already saved.
- Fix error when audio is unchanged when editing or updating happening survey.